### PR TITLE
Use Steam Web API for library data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__
 .coverage
 *.log
 *.egg-info
+.venv
+steam_api_key.dat

--- a/README.md
+++ b/README.md
@@ -7,12 +7,15 @@ This Jupyter Notebook allows you to quickly query a public Steam XML for a given
 1. Make sure your game information on Steam is set to 'Public'
 2. Clone the repo
 3. Create a `data` folder in the root directory
-4. From the root directory, run
+4. Activate the virtual environment via ./.venv/Scripts/activate
+5. Make sure there is a steam_id.dat with your Steam ID (vanity username) in the data folder.
+6. Make sure a Steam API key exists in data/steam_api_key.dat. You can get a Steam API key at https://steamcommunity.com/dev/apikey and use 'localhost' for the domain.
+7. From the root directory, run
 ```
 python .\src\main.py
 ```
-5. Go get a coffee, each game takes ~2 seconds to query due to query limits on SteamSpy API, so 500 games will take about 17 minutes. The script will create caches under the data folder to make subsequent queries almost instant.
-6. Under the data folder, you can find the analyzed data: your steam XML, a CSV with all of the raw data, and a few Bokeh graphs summarizing that data
+8. Go get a coffee, each game takes ~2 seconds to query due to query limits on SteamSpy API, so 500 games will take about 17 minutes. The script will create caches under the data folder to make subsequent queries almost instant.
+9. Under the data folder, you can find the analyzed data: your Steam game data, a CSV with all of the raw data, and a few Bokeh graphs summarizing that data
 
 Any issues will be logged into the output.log file.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ testpaths = [
 
 [tool.mypy]
 mypy_path = "src"
+python_version = "3.10"
 check_untyped_defs = true
 disallow_any_generics = true
 ignore_missing_imports = true

--- a/src/graphing/SteamDataBokehGraphGenerator.py
+++ b/src/graphing/SteamDataBokehGraphGenerator.py
@@ -31,6 +31,9 @@ class SteamDataBokehGraphGenerator:
         most_played_games = most_played_games.nlargest(50, colName)
         most_played_games = most_played_games.sort_values(by = [colName],
                                                           ascending = True)
+        if most_played_games.empty:
+            logging.warning("Skipping MostPlayed graph because it has no data")
+            return
 
         tooltips = [('Game', '@Name'), ('Hours Played', '@HoursOnRecord'),
                     ('Rating', '@BayesianAverage')]
@@ -92,6 +95,10 @@ class SteamDataBokehGraphGenerator:
         most_played_games_2w.drop(
             most_played_games_2w[most_played_games_2w[colName] == 0].index,
             inplace = True)
+        if most_played_games_2w.empty:
+            logging.warning(
+                "Skipping MostPlayedLast2Weeks graph because it has no data")
+            return
         most_played_games_2w = most_played_games_2w.sort_values(
             by = [colName], ascending = False)
 
@@ -132,6 +139,10 @@ class SteamDataBokehGraphGenerator:
         most_played_games = pd.DataFrame.copy(self.decorated_game_infos)
         most_played_games = most_played_games.sort_values(by = [colName],
                                                           ascending = False)
+        if most_played_games.empty:
+            logging.warning(
+                "Skipping MostPlayedVsRating graph because it has no data")
+            return
 
         tooltips = [('Game', '@Name'), ('Hours Played', '@HoursOnRecord'),
                     ('Rating', '@BayesianAverage')]
@@ -206,6 +217,10 @@ class SteamDataBokehGraphGenerator:
         best_unplayed_games = best_unplayed_games.nlargest(50, colName)
         best_unplayed_games = best_unplayed_games.sort_values(by = [colName],
                                                               ascending = True)
+        if best_unplayed_games.empty:
+            logging.warning(
+                "Skipping UnplayedPlainRating graph because it has no data")
+            return
 
         color_mapper = linear_cmap(field_name = colName,
                                    palette = palette,
@@ -281,6 +296,10 @@ class SteamDataBokehGraphGenerator:
         best_unplayed_games = best_unplayed_games.nlargest(50, colName)
         best_unplayed_games = best_unplayed_games.sort_values(by = [colName],
                                                               ascending = True)
+        if best_unplayed_games.empty:
+            logging.warning(
+                "Skipping UnplayedBayesian graph because it has no data")
+            return
 
         color_mapper = linear_cmap(field_name = colName,
                                    palette = palette,

--- a/src/main.py
+++ b/src/main.py
@@ -13,22 +13,37 @@ def query_steam_data_for_user(directory = ""):
     # Note, your 'Game details' must be set to 'Public' for this to work.
     # This is done in your profile -> Edit Profile -> Privacy Settings -> Game details
     # To find your username, check your profile under General -> Custom URL
+    # Get a free API key at https://steamcommunity.com/dev/apikey and
+    # save it to data/steam_api_key.dat
     username = ''
     if username == '':
         if os.path.exists(f"{directory}\\steam_id.dat"):
             logging.info('Reading steam ID from file')
             with open(f"{directory}\\steam_id.dat", "r",
                       encoding = "utf-8") as id_file:
-                username = id_file.read()
+                username = id_file.read().strip()
         else:
             logging.critical('Need steam user ID')
             raise Exception("Missing steam id")
 
-    cache_file = f"{directory}\\{username}_steam_games.xml"
+    api_key = os.environ.get("STEAM_API_KEY", "")
+    if not api_key:
+        api_key_file = f"{directory}\\steam_api_key.dat"
+        if os.path.exists(api_key_file):
+            logging.info('Reading Steam API key from file')
+            with open(api_key_file, "r", encoding="utf-8") as key_file:
+                api_key = key_file.read().strip()
+        else:
+            logging.critical('Need Steam API key')
+            raise Exception(
+                "Missing Steam API key - save it to data/steam_api_key.dat "
+                "or set STEAM_API_KEY env var")
+
+    cache_file = f"{directory}\\{username}_steam_games.json"
     if os.path.exists(cache_file):
         xmlProcessor = SteamXmlProcessor.from_file(cache_file)
     else:
-        xmlProcessor = SteamXmlProcessor.from_username(username, cache_file)
+        xmlProcessor = SteamXmlProcessor.from_username(api_key, username, cache_file)
 
     return xmlProcessor.get_game_infos()
 

--- a/src/steam/SteamSpyQuery.py
+++ b/src/steam/SteamSpyQuery.py
@@ -106,11 +106,16 @@ class SteamSpyQuery:
             })
         new_cache.set_index("AppId", inplace = True)
 
-        # Merge new cache and existing cache data
-        final_cache = pd.concat([cache, new_cache])
+        # Merge new cache and existing cache data.
+        frames = [df for df in [cache, new_cache] if not df.empty]
+        final_cache = (
+            pd.concat(frames)
+            if frames
+            else pd.DataFrame(columns = cache_columns).set_index("AppId"))
         if use_cache is True:
             final_cache.to_csv(cache_file)
 
-        # Add the new columns to the existing game_infos, drop Names since they're duplicated otherwise
+        # Add the new columns to the existing game_infos.
+        # Both DataFrames are indexed by AppId so join index-to-index.
         game_infos_df.drop("Name", axis = 1, inplace = True)
-        return game_infos_df.join(final_cache, on = "AppId", how = 'left')
+        return game_infos_df.join(final_cache, how = 'left')

--- a/src/steam/SteamSpyQuery.py
+++ b/src/steam/SteamSpyQuery.py
@@ -59,7 +59,24 @@ class SteamSpyQuery:
         if use_cache is True:
             cache_file = f"{self.output_directory}/steam_spy_cache.csv"
             if os.path.exists(cache_file):
-                cache = pd.read_csv(cache_file, index_col = "AppId")
+                cache = pd.read_csv(cache_file)
+                legacy_app_id_columns = [
+                    column for column in cache.columns
+                    if column.startswith("Unnamed:")
+                ]
+                for column in legacy_app_id_columns:
+                    cache["AppId"] = cache["AppId"].fillna(cache[column])
+                cache.drop(columns = legacy_app_id_columns,
+                           inplace = True,
+                           errors = "ignore")
+                cache.set_index("AppId", inplace = True)
+                cache.index = pd.to_numeric(cache.index, errors = "coerce")
+                invalid_cache_rows = cache.index.isna()
+                if invalid_cache_rows.any():
+                    logging.warning("Ignoring SteamSpy cache rows without AppId")
+                    cache = cache[~invalid_cache_rows]
+                cache.index = cache.index.astype("int64")
+                cache.index.name = "AppId"
         else:
             cache_file = ""
 
@@ -71,9 +88,8 @@ class SteamSpyQuery:
 
             cache_found = False
             if cache.empty is False:
-                cache_row = cache.loc[cache['Name'] == name]
-                if cache_row.empty is False:
-                    logging.info(f"Found {name} in cache")
+                if appid in cache.index:
+                    logging.info(f"Found {name} ({appid}) in cache")
                     cache_found = True
 
             if cache_found is False:
@@ -112,10 +128,11 @@ class SteamSpyQuery:
             pd.concat(frames)
             if frames
             else pd.DataFrame(columns = cache_columns).set_index("AppId"))
+        final_cache = final_cache[~final_cache.index.duplicated(keep = "last")]
         if use_cache is True:
             final_cache.to_csv(cache_file)
 
         # Add the new columns to the existing game_infos.
         # Both DataFrames are indexed by AppId so join index-to-index.
-        game_infos_df.drop("Name", axis = 1, inplace = True)
-        return game_infos_df.join(final_cache, how = 'left')
+        steam_spy_data = final_cache.drop(columns = ["Name"], errors = "ignore")
+        return game_infos_df.join(steam_spy_data, how = 'left')

--- a/src/steam/SteamXmlProcessor.py
+++ b/src/steam/SteamXmlProcessor.py
@@ -1,97 +1,107 @@
 import os
+import json
 from simplehttp.SimpleHttpClient import SimpleHttpClient
 import pandas as pd
-import xml.etree.ElementTree as ET
 
 
 class SteamXmlProcessor:
 
-    def __init__(self, data):
+    def __init__(self, data: dict):
         self.data = data
 
     @classmethod
     def from_file(cls, filename: str):
         if os.path.exists(filename):
-            with open(filename, "r", encoding = "utf-8") as games_file:
-                return cls(games_file.read())
+            with open(filename, "r", encoding="utf-8") as f:
+                return cls(json.load(f))
         else:
             raise Exception(f"{filename} does not exist")
 
     @classmethod
-    def from_username(cls, username: str, cache_file: str = ""):
-        xml_url = f'http://steamcommunity.com/id/{username}/games?tab=all&xml=1'
-        httpClient = SimpleHttpClient()
-        xml_contents = httpClient.get_request(xml_url, timeout = 5)
+    def from_username(cls, api_key: str, username: str, cache_file: str = ""):
+        http_client = SimpleHttpClient()
+
+        resolve_url = (
+            "https://api.steampowered.com/ISteamUser/"
+            "ResolveVanityURL/v0001/")
+        resolve_response = http_client.get_request(
+            resolve_url,
+            parameters={"key": api_key, "vanityurl": username},
+            timeout=10
+        )
+        resolve_data = resolve_response.json()
+
+        if resolve_data["response"]["success"] != 1:
+            raise Exception(f"Could not resolve Steam username: {username}")
+
+        steam_id = resolve_data["response"]["steamid"]
+
+        games_url = (
+            "https://api.steampowered.com/IPlayerService/"
+            "GetOwnedGames/v0001/")
+        games_response = http_client.get_request(
+            games_url,
+            parameters={
+                "key": api_key,
+                "steamid": steam_id,
+                "include_appinfo": 1,
+                "include_played_free_games": 1,
+                "format": "json",
+            },
+            timeout=10
+        )
+        games_data = games_response.json()
 
         if cache_file:
-            with open(cache_file, "w", encoding = "utf-8") as games_file:
-                games_file.write(xml_contents.text)
+            with open(cache_file, "w", encoding="utf-8") as f:
+                json.dump(games_data, f)
 
-        return cls(xml_contents.text)
+        return cls(games_data)
 
-    # Reads the games XML returned from get_steam_xml() and outputs a pandas dataframe
     def get_game_infos(self):
-
-        tree = ET.ElementTree(ET.fromstring(self.data))
-        root = tree.getroot()
-
-        if root.find('error') is not None:
-            raise Exception("Root not found")
+        games = self.data.get("response", {}).get("games", [])
 
         game_infos = []
+        for game in games:
+            app_id = game["appid"]
+            name = game.get("name", "Unknown")
 
-        for game in root.iter('game'):
-            app_id_node = game.find('appID')
-            if app_id_node is None:
-                raise Exception("Missing AppId Node for game")
-            app_id = app_id_node.text
+            img_hash = game.get("img_icon_url", "")
+            logo_link = (
+                "https://media.steampowered.com/steamcommunity/public/"
+                f"images/apps/{app_id}/{img_hash}.jpg"
+                if img_hash else ""
+            )
+            store_link = f"https://store.steampowered.com/app/{app_id}"
 
-            name_node = game.find('name')
-            if name_node is None:
-                raise Exception("Missing Name Node for game")
-            name = name_node.text
+            # API returns playtime in minutes; convert to integer hours
+            hours_last_2_weeks = int(game.get("playtime_2weeks", 0) / 60)
+            hours_on_record = int(game.get("playtime_forever", 0) / 60)
 
-            def propertyOrDefault(name, default: str) -> str:
-                name_node = game.find(name)
-                if name_node is None:
-                    return default
+            game_infos.append((
+                app_id, name, logo_link, store_link,
+                hours_last_2_weeks, hours_on_record,
+                "", ""
+            ))
 
-                result = name_node.text
-                if result is None:
-                    return ""
-                return result
-
-            # Rest of these are optional
-            logo_link = propertyOrDefault('logo', '')
-            store_link = propertyOrDefault('storeLink', '')
-            hours_last_2_weeks = float(
-                propertyOrDefault('hoursLast2Weeks', '0.0'))
-            hours_on_record = float(propertyOrDefault('hoursOnRecord', '0.0'))
-            stats_link = propertyOrDefault('statsLink', '')
-            global_stats_link = propertyOrDefault('globalStatsLink', '')
-
-            game_infos.append(
-                (app_id, name, logo_link, store_link, hours_last_2_weeks,
-                 hours_on_record, stats_link, global_stats_link))
-
-        df = pd.DataFrame.from_records(game_infos,
-                                       columns = [
-                                           'AppId', 'Name', 'LogoLink',
-                                           'StoreLink', 'HoursLast2Weeks',
-                                           'HoursOnRecord', 'StatsLink',
-                                           'GlobalStatsLink'
-                                       ])
-        df = df.astype(
-            dtype = {
-                'AppId': "int64",
-                'Name': "object",
-                'LogoLink': "object",
-                'StoreLink': "object",
-                'HoursLast2Weeks': "int64",
-                'HoursOnRecord': "int64",
-                'StatsLink': "object",
-                'GlobalStatsLink': "object"
-            })
-        df.set_index('AppId', inplace = True)
+        df = pd.DataFrame.from_records(
+            game_infos,
+            columns=[
+                "AppId", "Name", "LogoLink", "StoreLink",
+                "HoursLast2Weeks", "HoursOnRecord",
+                "StatsLink", "GlobalStatsLink"
+            ]
+        )
+        df = df.astype(dtype={
+            "AppId": "int64",
+            "Name": "object",
+            "LogoLink": "object",
+            "StoreLink": "object",
+            "HoursLast2Weeks": "int64",
+            "HoursOnRecord": "int64",
+            "StatsLink": "object",
+            "GlobalStatsLink": "object",
+        })
+        df.set_index("AppId", inplace=True)
 
         return df

--- a/src/steam/SteamXmlProcessor.py
+++ b/src/steam/SteamXmlProcessor.py
@@ -1,12 +1,14 @@
 import os
 import json
+from typing import Any
+
 from simplehttp.SimpleHttpClient import SimpleHttpClient
 import pandas as pd
 
 
 class SteamXmlProcessor:
 
-    def __init__(self, data: dict):
+    def __init__(self, data: dict[str, Any]):
         self.data = data
 
     @classmethod

--- a/tox.ini
+++ b/tox.ini
@@ -25,4 +25,4 @@ basepython = python3.10
 deps =
     -r{toxinidir}/requirements_dev.txt
 commands =
-    mypy --install-types --non-interactive src
+    mypy --no-site-packages src


### PR DESCRIPTION
## Summary
- Switch Steam library retrieval from the deprecated public XML endpoint to Steam Web API JSON responses
- Read a Steam API key from STEAM_API_KEY or data\steam_api_key.dat and cache owned games as JSON
- Preserve Steam API game names when joining SteamSpy data and recover AppIds from legacy SteamSpy cache files
- Stabilize CI mypy checks by avoiding auto-installed third-party stubs and skipping empty graph datasets with a warning

## Testing
- .\.venv\Scripts\python.exe .\src\main.py
- python -m py_compile src\steam\SteamSpyQuery.py src\graphing\SteamDataBokehGraphGenerator.py
- `$env:PYTHONPATH='src'; python -m mypy --no-site-packages src`
- git --no-pager diff --check
- GitHub Actions: Tests/test (windows-latest, 3.10) passing for push and pull_request