### PR TITLE
Include offline playtime in rankings

### DIFF
--- a/src/graphing/SteamDataBokehGraphGenerator.py
+++ b/src/graphing/SteamDataBokehGraphGenerator.py
@@ -17,48 +17,47 @@ class SteamDataBokehGraphGenerator:
         # Make bokeh log to file
         logconfig.basicConfig(level = logging.DEBUG, filename = "output.log")
 
-    def generate_most_played_games_graph(self):
-        # Plot most played games (ignore non played games)
-        colName = "HoursOnRecord"
-        output_file(f"{self.output_directory}/MostPlayed.html")
+    def _generate_most_played_games_graph_impl(self, col_name, title,
+                                               output_filename):
+        output_file(f"{self.output_directory}/{output_filename}")
 
         most_played_games = pd.DataFrame.copy(self.decorated_game_infos)
         most_played_games.drop(
-            most_played_games[most_played_games[colName] == 0].index,
+            most_played_games[most_played_games[col_name] == 0].index,
             inplace = True)
 
-        # Take just top 30
-        most_played_games = most_played_games.nlargest(50, colName)
-        most_played_games = most_played_games.sort_values(by = [colName],
+        # Take just top 50
+        most_played_games = most_played_games.nlargest(50, col_name)
+        most_played_games = most_played_games.sort_values(by = [col_name],
                                                           ascending = True)
         if most_played_games.empty:
-            logging.warning("Skipping MostPlayed graph because it has no data")
+            logging.warning(f"Skipping {output_filename} graph: no data")
             return
 
-        tooltips = [('Game', '@Name'), ('Hours Played', '@HoursOnRecord'),
+        tooltips = [('Game', '@Name'), ('Hours Played', f'@{col_name}'),
                     ('Rating', '@BayesianAverage')]
 
         select_tools = [
             'box_select', 'lasso_select', 'poly_select', 'tap', 'reset'
         ]
 
-        color_mapper = linear_cmap(field_name = colName,
+        color_mapper = linear_cmap(field_name = col_name,
                                    palette = palette,
-                                   low = min(most_played_games[colName]),
-                                   high = max(most_played_games[colName]))
+                                   low = min(most_played_games[col_name]),
+                                   high = max(most_played_games[col_name]))
 
         # Weird issue here where the text in LabelSet must be a string or it won't work, so decorate the data with strings
-        most_played_games[f"{colName}Text"] = most_played_games[colName].apply(
-            lambda x: str(x))
+        most_played_games[f"{col_name}Text"] = most_played_games[
+            col_name].apply(lambda x: str(x))
         data_source = ColumnDataSource(most_played_games)
 
         p = figure(
             y_range = most_played_games["Name"],
             width = 2000,
             height = 1250,
-            title = "Most Played Games of All Time",
+            title = title,
             tools = select_tools,
-            x_range = (0, max(most_played_games[colName] + 20)),
+            x_range = (0, max(most_played_games[col_name] + 20)),
         )
 
         p.title.text_font_size = '32pt'
@@ -68,23 +67,39 @@ class SteamDataBokehGraphGenerator:
 
         p.hbar(y = "Name",
                left = 0,
-               right = colName,
+               right = col_name,
                height = 0.5,
                source = data_source,
                color = color_mapper)
         p.add_tools(HoverTool(tooltips = tooltips))
 
-        labels = LabelSet(x = colName,
+        labels = LabelSet(x = col_name,
                           y = "Name",
                           level = 'annotation',
                           text_color = 'black',
                           x_offset = 5,
                           y_offset = -6,
-                          text = f"{colName}Text",
+                          text = f"{col_name}Text",
                           source = data_source)
 
         p.add_layout(labels)
         save(p)
+
+    def generate_most_played_games_graph(self):
+        # Plot most played games including offline/disconnected time
+        self._generate_most_played_games_graph_impl(
+            col_name = "HoursOnRecord",
+            title = "Most Played Games of All Time (Online + Offline)",
+            output_filename = "MostPlayed.html"
+        )
+
+    def generate_most_played_games_online_graph(self):
+        # Plot most played games using online playtime only
+        self._generate_most_played_games_graph_impl(
+            col_name = "HoursOnRecordOnline",
+            title = "Most Played Games of All Time (Online Only)",
+            output_filename = "MostPlayedOnline.html"
+        )
 
     def generate_most_played_games_2weeks_graph(self):
         # Plot most played games in last 2 weeks

--- a/src/main.py
+++ b/src/main.py
@@ -75,9 +75,13 @@ def main():
     decorated_game_infos = decorated_game_infos.sort_values(
         by = ['BayesianAverage'], ascending = False)
 
-    # DLCs have no ratings, drop them from the list
+    # DLCs have no ratings and are unplayed; keep any game that has been played
+    # even if SteamSpy has no rating data for it (e.g. new Early Access titles)
     decorated_game_infos.drop(
-        decorated_game_infos[decorated_game_infos["RatingsRatio"] == 0].index,
+        decorated_game_infos[
+            (decorated_game_infos["RatingsRatio"] == 0) &
+            (decorated_game_infos["HoursOnRecord"] == 0)
+        ].index,
         inplace = True)
 
     # Write to file for easy access
@@ -86,6 +90,7 @@ def main():
     graph_generator = SteamDataBokehGraphGenerator(decorated_game_infos,
                                                    data_directory)
     graph_generator.generate_most_played_games_graph()
+    graph_generator.generate_most_played_games_online_graph()
     graph_generator.generate_most_played_games_2weeks_graph()
     graph_generator.generate_most_played_games_versus_rating_graph()
     graph_generator.generate_best_unplayed_games_average()

--- a/src/steam/SteamXmlProcessor.py
+++ b/src/steam/SteamXmlProcessor.py
@@ -76,13 +76,19 @@ class SteamXmlProcessor:
             )
             store_link = f"https://store.steampowered.com/app/{app_id}"
 
-            # API returns playtime in minutes; convert to integer hours
+            # API returns playtime in minutes; convert to integer hours.
+            # playtime_forever is online-only; playtime_disconnected holds
+            # time played in Steam offline mode and must be added separately.
             hours_last_2_weeks = int(game.get("playtime_2weeks", 0) / 60)
-            hours_on_record = int(game.get("playtime_forever", 0) / 60)
+            hours_on_record_online = int(game.get("playtime_forever", 0) / 60)
+            hours_on_record = int(
+                (game.get("playtime_forever", 0) +
+                 game.get("playtime_disconnected", 0)) / 60
+            )
 
             game_infos.append((
                 app_id, name, logo_link, store_link,
-                hours_last_2_weeks, hours_on_record,
+                hours_last_2_weeks, hours_on_record_online, hours_on_record,
                 "", ""
             ))
 
@@ -90,7 +96,7 @@ class SteamXmlProcessor:
             game_infos,
             columns=[
                 "AppId", "Name", "LogoLink", "StoreLink",
-                "HoursLast2Weeks", "HoursOnRecord",
+                "HoursLast2Weeks", "HoursOnRecordOnline", "HoursOnRecord",
                 "StatsLink", "GlobalStatsLink"
             ]
         )
@@ -100,6 +106,7 @@ class SteamXmlProcessor:
             "LogoLink": "object",
             "StoreLink": "object",
             "HoursLast2Weeks": "int64",
+            "HoursOnRecordOnline": "int64",
             "HoursOnRecord": "int64",
             "StatsLink": "object",
             "GlobalStatsLink": "object",


### PR DESCRIPTION
## Summary
- Include Steam offline/disconnected playtime in total hours played while keeping online-only hours separately
- Add a separate most-played graph for online-only playtime
- Keep played games even when SteamSpy has no rating data, while still filtering unplayed unrated entries

## Testing
- .\.venv\Scripts\python.exe .\src\main.py
- python -m py_compile src\main.py src\steam\SteamXmlProcessor.py src\graphing\SteamDataBokehGraphGenerator.py
- `$env:PYTHONPATH='src'; python -m mypy --no-site-packages src`
- git --no-pager diff --check