### PR TITLE
Switch to Steam Web API and add per-device playtime graphs

### DIFF
--- a/src/graphing/SteamDataBokehGraphGenerator.py
+++ b/src/graphing/SteamDataBokehGraphGenerator.py
@@ -101,6 +101,15 @@ class SteamDataBokehGraphGenerator:
             output_filename = "MostPlayedOnline.html"
         )
 
+    def generate_most_played_games_deck_graph(self):
+        # Plot most played games on Steam Deck (online time only — offline
+        # playtime is not tracked per-device by the Steam API)
+        self._generate_most_played_games_graph_impl(
+            col_name = "HoursOnRecordDeck",
+            title = "Most Played Games on Steam Deck (Online Only)",
+            output_filename = "MostPlayedDeck.html"
+        )
+
     def generate_most_played_games_2weeks_graph(self):
         # Plot most played games in last 2 weeks
         colName = "HoursLast2Weeks"

--- a/src/main.py
+++ b/src/main.py
@@ -91,6 +91,7 @@ def main():
                                                    data_directory)
     graph_generator.generate_most_played_games_graph()
     graph_generator.generate_most_played_games_online_graph()
+    graph_generator.generate_most_played_games_deck_graph()
     graph_generator.generate_most_played_games_2weeks_graph()
     graph_generator.generate_most_played_games_versus_rating_graph()
     graph_generator.generate_best_unplayed_games_average()

--- a/src/steam/SteamXmlProcessor.py
+++ b/src/steam/SteamXmlProcessor.py
@@ -85,11 +85,14 @@ class SteamXmlProcessor:
                 (game.get("playtime_forever", 0) +
                  game.get("playtime_disconnected", 0)) / 60
             )
+            hours_on_record_deck = int(
+                game.get("playtime_deck_forever", 0) / 60
+            )
 
             game_infos.append((
                 app_id, name, logo_link, store_link,
                 hours_last_2_weeks, hours_on_record_online, hours_on_record,
-                "", ""
+                hours_on_record_deck, "", ""
             ))
 
         df = pd.DataFrame.from_records(
@@ -97,7 +100,7 @@ class SteamXmlProcessor:
             columns=[
                 "AppId", "Name", "LogoLink", "StoreLink",
                 "HoursLast2Weeks", "HoursOnRecordOnline", "HoursOnRecord",
-                "StatsLink", "GlobalStatsLink"
+                "HoursOnRecordDeck", "StatsLink", "GlobalStatsLink"
             ]
         )
         df = df.astype(dtype={
@@ -108,6 +111,7 @@ class SteamXmlProcessor:
             "HoursLast2Weeks": "int64",
             "HoursOnRecordOnline": "int64",
             "HoursOnRecord": "int64",
+            "HoursOnRecordDeck": "int64",
             "StatsLink": "object",
             "GlobalStatsLink": "object",
         })


### PR DESCRIPTION
## Summary

- **Steam API migration**: the old `steamcommunity.com/id/{user}/games?xml=1` endpoint now redirects to a login page. Replaced with the official Steam Web API (`IPlayerService/GetOwnedGames`), which requires a free API key saved to `data/steam_api_key.dat` (or `STEAM_API_KEY` env var). Vanity URLs are resolved automatically via `ResolveVanityURL`.
- **Offline playtime**: `playtime_forever` is online-only; time played in Steam offline mode lives in `playtime_disconnected`. Both are now summed into `HoursOnRecord` so games played primarily offline (e.g. Super Meat Boy) appear correctly.
- **Per-device playtime graphs**: added `HoursOnRecordOnline` and `HoursOnRecordDeck` columns, and two new graphs — `MostPlayedOnline.html` (online hours only) and `MostPlayedDeck.html` (Steam Deck online hours; per-device offline time is not available in the API).
- **DLC filter fix**: the `RatingsRatio == 0` filter now also requires `HoursOnRecord == 0`, so played Early Access games (e.g. Slay the Spire 2) are no longer incorrectly dropped.
- **SteamSpy fixes**: suppress pandas `FutureWarning` from concatenating an empty cache DataFrame; fix `ValueError` in Bokeh caused by `AppId` appearing as both index and column after a misused `join(on=)`.

## Test plan

- [ ] Confirm `data/steam_api_key.dat` and `data/steam_id.dat` are present before running
- [ ] Delete any old `data/*_steam_games.xml` cache files (format changed to `.json`)
- [ ] Run `python src/main.py` and verify no errors in `output.log`
- [ ] Check `data/` for `MostPlayed.html`, `MostPlayedOnline.html`, `MostPlayedDeck.html`
- [ ] Verify offline-heavy games (Super Meat Boy) appear in `MostPlayed.html`
- [ ] Verify played Early Access games (Slay the Spire 2) are not filtered out

🤖 Generated with [Claude Code](https://claude.com/claude-code)